### PR TITLE
[fix] sandbox reducer behavior

### DIFF
--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -70,14 +70,16 @@ export function wrapProtoMethod(executor) {
   };
 
   Array.prototype.reduce = function reduce(reducer, init) {
-    if (typeof reducer === 'function' && funcToString.call(reducer).indexOf(FUNC_MARK) !== -1) {
-      return executor((function* (array) {
-        let result = init;
-        for (let i = 0; i < array.length; i++) result = yield reducer(result, array[i], i, array);
-        return result;
-      })(this));
-    }
-    return oriArrayReduce.call(this, reducer, init);
+    const hasInit = arguments.length > 1;
+      if (typeof reducer === 'function' && funcToString.call(reducer).indexOf(FUNC_MARK) !== -1) {
+        return executor(function* (array) {
+          let result = hasInit? init : array[0];
+          for (let i = hasInit ? 0 : 1; i < array.length; i++) result = yield reducer(result, array[i], i, array);
+          return result;
+        }(this));
+      }
+      if(hasInit) return oriArrayReduce.call(this, reducer, init);
+      return oriArrayReduce.call(this, reducer);
   };
 
   Array.prototype.reduceRight = function reduceRight(reducer, init) {


### PR DESCRIPTION
The results of arr.reduce(reducer) and arr.reduce(reducer, undefined) are different.